### PR TITLE
docs: Add report on professional-grade K8s improvements and bump component versions

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,40 @@
+# Making the Kubernetes Distro "Professional-Grade"
+
+This report outlines several areas of improvement to elevate this custom Kubernetes distribution from a testbench (currently somewhat fragile and expressive) to a robust, professional-grade platform based on recent Kubernetes community releases and best practices.
+
+## 1. Architectural and Deployment Strategy
+
+### Stop Compiling on the Deployment Target (or at all, if possible)
+Currently, the codebase downloads and builds Kubernetes, containerd, runc, crun, CNI plugins, and even Kata containers directly from source. While beneficial for learning and development:
+* **Professional Grade:** A production-grade distro relies on pre-compiled, signed binaries or OCI images from official release channels (e.g., `registry.k8s.io`). If custom patches are needed, build them once in an automated CI pipeline and host the artifacts in a private registry/object store. This significantly reduces deployment time, resource requirements on nodes, and eliminates build-time dependencies (like compilers or `go` toolchains) from the production environment, reducing the attack surface.
+* **Declarative Provisioning:** Using pure bash scripts and ssh for cluster lifecycle management is prone to errors, state drift, and lacks idempotency. Moving towards a tool like **Cluster API (CAPI)**, **Kubeadm**, or at least a fully developed **Ansible** collection (like Kubespray) will make the distro resilient and maintainable.
+
+## 2. Component Upgrades and Best Practices
+
+### Control Plane Modernization
+* **etcd:** The current setup relies on a manually downloaded `v3.5.5` binary. Ensure the etcd version perfectly aligns with the Kubernetes version support matrix (for 1.30, v3.5.12+ is recommended).
+* **High Availability (HA):** While the framework supports multiple masters, relying on manual DNS updates or an external bash-managed `haproxy` is not cloud-native. Implementing Keepalived + HAProxy natively or using a cloud-provider load balancer integration is standard.
+* **Component Configurations:**
+  * Ensure the use of `v1` configuration APIs (e.g., `KubeletConfiguration`, `KubeProxyConfiguration`). The scripts were using `v1beta1`/`v1alpha1`, which may be deprecated or removed in newer releases (like 1.30).
+  * Use **Structured Logging** for control plane components. This is the modern standard for k8s components, making log ingestion and aggregation (e.g., via Promtail/Loki or FluentBit) vastly superior.
+
+### Container Runtime Interface (CRI)
+* **Containerd 1.7+ & runc 1.1+:** The distro now defaults to `containerd` 1.7.x. Ensure `SystemdCgroup = true` is explicitly configured in `containerd/config.toml` (v2 configuration format) and Kubelet, rather than using `cgroupfs`. This is an absolute requirement for modern systemd-based Linux distributions (like Ubuntu 22.04+) to prevent instability and resource management conflicts.
+* **cgroup v2:** Ensure full support for `cgroup v2`. Ubuntu 22.04 uses cgroup v2 by default. Some older runtimes (like the `gVisor` note in the README) historically struggled with this, but recent versions have improved. Disabling unified cgroup hierarchy via grub is an anti-pattern for modern systems.
+
+### Networking and CNI
+* **Move to eBPF-based Networking (Cilium):** The current script supports `default` (simple bridge), `calico`, and `cilium`. For a professional-grade distro, **Cilium** is widely considered the industry standard due to its eBPF dataplane, offering superior performance, observability (Hubble), and security (NetworkPolicies, transparent encryption).
+* **Gateway API vs. Ingress:** The traditional Ingress API is effectively superseded by the **Gateway API**. A modern distro should ship with a Gateway API implementation (like Cilium's native Gateway API, or Envoy Gateway) rather than an old NGINX ingress controller.
+
+### Security Enhancements
+* **Pod Security Standards (PSS):** With the removal of Pod Security Policies (PSP), the distro should configure the built-in **Pod Security Admission (PSA)** controller on the API server to enforce baseline or restricted policies across namespaces.
+* **Kubelet Security:** Disable anonymous authentication (`--anonymous-auth=false`) and enable `NodeRestriction` admission controller (already present in the script, which is good). Ensure read-only ports are disabled.
+* **Seccomp and AppArmor:** Ensure default Seccomp profiles (`RuntimeDefault`) are enabled across the cluster.
+
+## 3. Observability and Day-2 Operations
+
+* **Metrics Server:** A professional distro requires the `metrics-server` installed by default to support Horizontal Pod Autoscalers (HPA) and `kubectl top`.
+* **Logging and Monitoring Stack:** Consider providing a built-in or easily toggleable stack such as Prometheus/Grafana (kube-prometheus-stack) and Fluent-bit/Loki.
+
+## Conclusion
+By shifting away from local compilation, adopting robust provisioning tools, embracing eBPF networking via Cilium, and updating configurations to current standard APIs (like cgroup v2 and Gateway API), this testbench can evolve into a highly capable, professional-grade Kubernetes distribution.

--- a/README.md
+++ b/README.md
@@ -33,17 +33,20 @@ k8s:
   ncpnd: 1
   nwrknd: 2
   cni: "default"
-  V: 1.25
-  CRI_CTL_V: 1.25
-  RUNC_V: 1.1
+  V: 1.30
+  CRI_CTL_V: 1.30
+  RUNC_V: 1.1.12
   CRUN_V: 1.7
-  CONTD_V: 1.6
-  CNI_PLUGIN_V: 1.1
+  CONTD_V: 1.7
+  CNI_PLUGIN_V: 1.5
   build_directory: "<path>"
 node:
   private_key_name: "ssh_key"
   os: "generic/ubuntu2204"
 </code></pre>
+
+> **Note:** For a comprehensive architectural and component-level review on how to evolve this testbench into a "professional-grade" Kubernetes distribution, please refer to the [IMPROVEMENTS.md](./IMPROVEMENTS.md) document.
+
 Github repo documentation still a work in progress and grow along with this series and will bring more clarity, it's only bash scripts (other than one exception of ansible, just to keep an entry point for future enhancement), using only bash is intentional, code is very much straight forward easy to understand and change and that is the primary objectives.
 
 following table would be helpful

--- a/k8s-config.yaml
+++ b/k8s-config.yaml
@@ -37,7 +37,7 @@ k8s:
   CNI_PLUGIN_V: 1.5
   build_directory: "/path/to/build_directory"
   runtime: "runc"
-  runtime_v: 1.1.12
+  runtime_v: 1.1
 node:
   private_key_name: "ssh_key_name"
   os: "generic/ubuntu2204"

--- a/k8s-config.yaml
+++ b/k8s-config.yaml
@@ -31,13 +31,13 @@ k8s:
   ncpnd: 1
   nwrknd: 0
   cni: "default"
-  V: 1.25
-  CRI_CTL_V: 1.25
-  CONTD_V: 1.6
-  CNI_PLUGIN_V: 1.1
+  V: 1.30
+  CRI_CTL_V: 1.30
+  CONTD_V: 1.7
+  CNI_PLUGIN_V: 1.5
   build_directory: "/path/to/build_directory"
   runtime: "runc"
-  runtime_v: 1.1
+  runtime_v: 1.1.12
 node:
   private_key_name: "ssh_key_name"
   os: "generic/ubuntu2204"

--- a/templates/configure-worker.sh.template
+++ b/templates/configure-worker.sh.template
@@ -187,9 +187,9 @@ egrep -c '(vmx|svm)' /proc/cpuinfo
 grep -E --color '(vmx|svm)' /proc/cpuinfo
 
 echo "Installing golang and preparing node to build and install kata runtime"
-wget https://go.dev/dl/go1.19.3.linux-amd64.tar.gz
-sha256sum go1.19.3.linux-amd64.tar.gz
-sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.19.3.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.22.4.linux-amd64.tar.gz
+sha256sum go1.22.4.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz
 sudo cp /usr/local/go/bin/go /usr/local/bin/
 mkdir -p \$HOME/go_projects/{bin,src,pkg}
 


### PR DESCRIPTION
This PR adds a comprehensive report (`IMPROVEMENTS.md`) outlining architectural, security, and component-level improvements to evolve this Kubernetes testbench into a professional-grade distribution. It also bumps the default Kubernetes component versions in `k8s-config.yaml` to their recent stable releases (e.g., Kubernetes 1.30, Containerd 1.7.x) and updates the Go compilation dependency for worker nodes to 1.22.4 to support modern builds.

---
*PR created automatically by Jules for task [17196269782193708788](https://jules.google.com/task/17196269782193708788) started by @amartyamandal*